### PR TITLE
feat: add support for installation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,62 @@ You can configure the PAC installation with the following options:
 - `--show-config`: Show the PAC configuration.
 - `--apply-non-root`: Apply non-root configuration to the PAC controller.
 
+## Hooks
+
+startpaac supports hooks — executable scripts that run automatically at defined
+points in the installation flow. This lets you customize the process (e.g.,
+apply extra K8s resources after Tekton installs, patch configs before PAC
+deploys) without forking or running scripts manually.
+
+### Hook Directory
+
+Hooks are discovered from `~/.config/startpaac/hooks/` (override via the
+`HOOKS_DIR` environment variable).
+
+### Naming Convention
+
+Hook files are named `pre-<component>` or `post-<component>`. For example:
+
+- `pre-install-tekton` — runs before Tekton is installed
+- `post-configure-pac` — runs after PAC is configured
+
+Available hook points: `all`, `sync-kubeconfig`, `install-nginx`,
+`install-registry`, `install-tekton`, `install-triggers`, `install-chains`,
+`install-dashboard`, `install-pac`, `configure-pac`,
+`configure-pac-custom-certs`, `patch-pac-service-nodeport`, `install-forgejo`,
+`install-postgresql`, `install-custom-objects`, `install-github-second-ctrl`.
+
+### Format
+
+A hook can be either:
+
+- A single executable file (e.g., `~/.config/startpaac/hooks/post-install-tekton`)
+- A directory of executable files, run in sorted order (e.g.,
+  `~/.config/startpaac/hooks/post-install-tekton/01-apply-extras`,
+  `~/.config/startpaac/hooks/post-install-tekton/02-patch-config`)
+
+### Environment
+
+All existing environment variables are inherited (`KUBECONFIG`, `TARGET_HOST`,
+`DOMAIN_NAME`, `PAC_DIR`, `CI_MODE`, etc.). Additionally,
+`STARTPAAC_HOOK_NAME` is exported with the current hook name.
+
+### Failure Behavior
+
+A non-zero exit from any hook script aborts the startpaac run.
+
+### Example
+
+```bash
+mkdir -p ~/.config/startpaac/hooks
+cat > ~/.config/startpaac/hooks/post-install-tekton <<'EOF'
+#!/bin/bash
+echo "Tekton installed — applying custom resources"
+kubectl apply -f ~/my-extra-resources/
+EOF
+chmod +x ~/.config/startpaac/hooks/post-install-tekton
+```
+
 ## ZSH Completion
 
 There is a [ZSH completion script](./misc/_startpaac) that can get installed in your

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -280,3 +280,40 @@ spec:
 EOF
   kubectl apply -f /tmp/${deploymentName}.yaml
 }
+
+HOOKS_DIR="${HOOKS_DIR:-${HOME}/.config/startpaac/hooks}"
+
+run_hook() {
+    local hook_name="$1"
+    local hook_path="${HOOKS_DIR}/${hook_name}"
+
+    [[ -d "${HOOKS_DIR}" ]] || return 0
+
+    local -a hook_files=()
+    if [[ -x "${hook_path}" && -f "${hook_path}" ]]; then
+        hook_files=("${hook_path}")
+    elif [[ -d "${hook_path}" ]]; then
+        while IFS= read -r f; do
+            [[ -x "$f" && -f "$f" ]] && hook_files+=("$f")
+        done < <(find "${hook_path}" -maxdepth 1 -type f | sort)
+    fi
+
+    [[ ${#hook_files[@]} -eq 0 ]] && return 0
+
+    export STARTPAAC_HOOK_NAME="${hook_name}"
+    for hook_file in "${hook_files[@]}"; do
+        local display_name="${hook_name}"
+        [[ ${#hook_files[@]} -gt 1 ]] && display_name="${hook_name}/$(basename "${hook_file}")"
+        echo_color cyan "Running hook: ${display_name}"
+        "${hook_file}"
+        echo_color green "Hook '${display_name}' completed"
+    done
+}
+
+run_with_hooks() {
+    local hook_name="$1"
+    shift
+    run_hook "pre-${hook_name}"
+    "$@"
+    run_hook "post-${hook_name}"
+}

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -42,6 +42,13 @@ elif [[ -z ${PAC_DIR:-} ]]; then
 #
 # Install custom objects in the kind cluster after the cluster is created
 # INSTALL_CUSTOM_OBJECT=~/path/to/dir/
+#
+# HOOKS_DIR is the directory where hook scripts are loaded from.
+# Hooks are executable files named pre-<component> or post-<component>
+# (e.g., post-install-tekton) that run automatically at defined points
+# in the installation flow. A hook can be a single executable file or
+# a directory of executable files (run in sorted order).
+# HOOKS_DIR=~/.config/startpaac/hooks
 ## Hosts (not needed if TARGET_HOST is set to local)
 #
 # setup a wildcard dns *.lan.mydomain.com to go to your TARGET_HOST vm

--- a/startpaac
+++ b/startpaac
@@ -618,34 +618,36 @@ function set_namespace() {
 }
 
 all() {
-  sync_kubeconfig
-  install_nginx
-  install_registry
-  install_tekton
+  run_hook pre-all
+
+  run_with_hooks sync-kubeconfig sync_kubeconfig
+  run_with_hooks install-nginx install_nginx
+  run_with_hooks install-registry install_registry
+  run_with_hooks install-tekton install_tekton
 
   # Optional Tekton components
-  [[ ${INSTALL_TEKTON_TRIGGERS} == "true" ]] && install_triggers
-  [[ ${INSTALL_TEKTON_CHAINS} == "true" ]] && install_chains
-  [[ ${INSTALL_TEKTON_DASHBOARD} == "true" ]] && install_dashboard
+  [[ ${INSTALL_TEKTON_TRIGGERS} == "true" ]] && run_with_hooks install-triggers install_triggers
+  [[ ${INSTALL_TEKTON_CHAINS} == "true" ]] && run_with_hooks install-chains install_chains
+  [[ ${INSTALL_TEKTON_DASHBOARD} == "true" ]] && run_with_hooks install-dashboard install_dashboard
 
   # PAC (optional)
   [[ ${INSTALL_PAC} == "true" ]] && {
-    install_pac
-    configure_pac
-    configure_pac_custom_certs
-    patch_pac_service_nodeport
+    run_with_hooks install-pac install_pac
+    run_with_hooks configure-pac configure_pac
+    run_with_hooks configure-pac-custom-certs configure_pac_custom_certs
+    run_with_hooks patch-pac-service-nodeport patch_pac_service_nodeport
   }
 
   # Other optional components
-  [[ ${INSTALL_FORGE} == "true" ]] && install_forgejo ${FORGE_HOST}
-  [[ ${INSTALL_POSTGRESQL} == "true" ]] && install_postgresql
-  [[ -n ${INSTALL_CUSTOM_OBJECT:-} && ${INSTALL_CUSTOM_OBJECT_ENABLED} == "true" ]] && install_custom_objects
+  [[ ${INSTALL_FORGE} == "true" ]] && run_with_hooks install-forgejo install_forgejo ${FORGE_HOST}
+  [[ ${INSTALL_POSTGRESQL} == "true" ]] && run_with_hooks install-postgresql install_postgresql
+  [[ -n ${INSTALL_CUSTOM_OBJECT:-} && ${INSTALL_CUSTOM_OBJECT_ENABLED} == "true" ]] && run_with_hooks install-custom-objects install_custom_objects
 
   # In CI mode, auto-enable second controller if secrets are present
   if [[ ${CI_MODE} == "true" ]] && [[ -n ${PAC_SECOND_SECRET_FOLDER:-} ]] && [[ -e ${PAC_SECOND_SECRET_FOLDER}/github-application-id ]]; then
     INSTALL_GITHUB_SECOND_CTRL=true
   fi
-  [[ ${INSTALL_GITHUB_SECOND_CTRL} == "false" || ${INSTALL_GITHUB_SECOND_CTRL} == "" ]] || install_github_second_ctrl
+  [[ ${INSTALL_GITHUB_SECOND_CTRL} == "false" || ${INSTALL_GITHUB_SECOND_CTRL} == "" ]] || run_with_hooks install-github-second-ctrl install_github_second_ctrl
 
   if [[ "${USE_NODEPORT_WEBHOOK}" != "true" ]]; then
     start_user_gosmee gosmee
@@ -655,6 +657,8 @@ all() {
 
   show_step "Setting current namespace context to pipelines-as-code"
   set_namespace pipelines-as-code
+
+  run_hook post-all
 }
 
 function help() {


### PR DESCRIPTION
Implemented a hook mechanism that allows users to run custom scripts before and after major installation steps. Added `run_with_hooks` to wrap existing functions, supporting single executable files or sorted directories from a configurable `HOOKS_DIR`.