### PR TITLE
Reapply Forgejo webhook support and standardize project naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 StartPAAC - All in one setup for Pipelines as Code on Kind
+# 🚀 StartPAC - All in one setup for Pipelines as Code on Kind
 
 [![ShellCheck](https://github.com/chmouel/startpaac/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/chmouel/startpaac/actions/workflows/shellcheck.yml)
 
@@ -231,7 +231,7 @@ Create a configuration file at `$HOME/.config/startpaac/config` with the followi
 # https://nextdns.io to let you create wildcard dns for your local network.
 #
 # DOMAIN_NAME=lan.mydomain.com
-# PAAC=paac.${DOMAIN_NAME}
+# PAC=paac.${DOMAIN_NAME}
 # REGISTRY=registry.${DOMAIN_NAME}
 # FORGE_HOST=gitea.${DOMAIN_NAME}
 # DASHBOARD=dashboard.${DASHBOARD}
@@ -240,7 +240,7 @@ Create a configuration file at `$HOME/.config/startpaac/config` with the followi
 # TARGET_HOST=civuole.lan
 # KO_EXTRA_FLAGS=(--insecure-registry --platform linux/arm64)
 # DOMAIN_NAME=vm.lan
-# PAAC=paac.${DOMAIN_NAME}
+# PAC=paac.${DOMAIN_NAME}
 # REGISTRY=registry.${DOMAIN_NAME}
 # FORGE_HOST=gitea.${DOMAIN_NAME}
 # TARGET_BIND_IP=192.168.1.5

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Create a configuration file at `$HOME/.config/startpaac/config` with the followi
 # PAC_DIR=$GOPATH/src/github.com/openshift-pipelines/pac/main
 ```
 
-You can have an alternative config file with the `STARTPAAC_CONFIG_FILE`
+You can have an alternative config file with the `STARTPAC_CONFIG_FILE`
 environment variable.
 
 ## PostgreSQL Configuration
@@ -513,7 +513,7 @@ A hook can be either:
 
 All existing environment variables are inherited (`KUBECONFIG`, `TARGET_HOST`,
 `DOMAIN_NAME`, `PAC_DIR`, `CI_MODE`, etc.). Additionally,
-`STARTPAAC_HOOK_NAME` is exported with the current hook name.
+`STARTPAC_HOOK_NAME` is exported with the current hook name.
 
 ### Failure Behavior
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,16 +1,16 @@
-# StartPAAC Architecture
+# StartPAC Architecture
 
-This document describes the architecture and design of StartPAAC, an automated setup tool for Pipelines as Code development environments.
+This document describes the architecture and design of StartPAC, an automated setup tool for Pipelines as Code development environments.
 
 ## Overview
 
-StartPAAC is a modular Bash-based orchestration tool that automates the creation of a complete Pipelines as Code development environment on Kubernetes using Kind (Kubernetes in Docker).
+StartPAC is a modular Bash-based orchestration tool that automates the creation of a complete Pipelines as Code development environment on Kubernetes using Kind (Kubernetes in Docker).
 
 ## High-Level Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                         StartPAAC CLI                           │
+│                         StartPAC CLI                           │
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │  Interactive Menu (gum) │ Preferences (JSON) │ Config     │  │
 │  └───────────────────────────────────────────────────────────┘  │

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -300,7 +300,7 @@ run_hook() {
 
     [[ ${#hook_files[@]} -eq 0 ]] && return 0
 
-    export STARTPAAC_HOOK_NAME="${hook_name}"
+    export STARTPAC_HOOK_NAME="${hook_name}"
     for hook_file in "${hook_files[@]}"; do
         local display_name="${hook_name}"
         [[ ${#hook_files[@]} -gt 1 ]] && display_name="${hook_name}/$(basename "${hook_file}")"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -305,7 +305,10 @@ run_hook() {
         local display_name="${hook_name}"
         [[ ${#hook_files[@]} -gt 1 ]] && display_name="${hook_name}/$(basename "${hook_file}")"
         echo_color cyan "Running hook: ${display_name}"
-        "${hook_file}"
+        if ! "${hook_file}"; then
+            echo_color red "Hook '${display_name}' failed"
+            return 1
+        fi
         echo_color green "Hook '${display_name}' completed"
     done
 }
@@ -313,7 +316,7 @@ run_hook() {
 run_with_hooks() {
     local hook_name="$1"
     shift
-    run_hook "pre-${hook_name}"
-    "$@"
+    run_hook "pre-${hook_name}" || return $?
+    "$@" || return $?
     run_hook "post-${hook_name}"
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -56,7 +56,7 @@ elif [[ -z ${PAC_DIR:-} ]]; then
 # https://nextdns.io to let you create wildcard dns for your local network.
 #
 # DOMAIN_NAME=lan.mydomain.com
-# PAAC=paac.\${DOMAIN_NAME}
+# PAC=paac.\${DOMAIN_NAME}
 # REGISTRY=registry.\${DOMAIN_NAME}
 # FORGE_HOST=gitea.\${DOMAIN_NAME}
 # DASHBOARD=dashboard.\${DASHBOARD}
@@ -66,7 +66,7 @@ elif [[ -z ${PAC_DIR:-} ]]; then
 # TARGET_HOST=civuole.lan
 # KO_EXTRA_FLAGS=(--insecure-registry --platform linux/arm64)
 # DOMAIN_NAME=vm.lan
-# PAAC=paac.\${DOMAIN_NAME}
+# PAC=paac.\${DOMAIN_NAME}
 # REGISTRY=registry.\${DOMAIN_NAME}
 # FORGE_HOST=gitea.\${DOMAIN_NAME}
 # TARGET_BIND_IP=192.168.1.5

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash disable=SC1090
-CONFIG_FILE=${STARTPAAC_CONFIG_FILE:-$HOME/.config/startpaac/config}
+CONFIG_FILE=${STARTPAC_CONFIG_FILE:-$HOME/.config/startpaac/config}
 echo "Loading configuration from ${CONFIG_FILE}"
 
 if [[ -e "${CONFIG_FILE}" ]]; then

--- a/misc/forgejo-mng/main.py
+++ b/misc/forgejo-mng/main.py
@@ -251,8 +251,14 @@ def create_pull_request_api(
     default="",
     help="Direct webhook URL (e.g., http://127.0.0.1:30080), takes precedence over smee-url",
 )
+@click.option(
+    "--webhook-secret",
+    envvar="PAC_WEBHOOK_SECRET",
+    default="",
+    help="Webhook secret for HMAC signature verification",
+)
 @click.pass_context
-def cli(ctx, forgejo_url, username, password, repo_owner, skip_tls, webhook_url):
+def cli(ctx, forgejo_url, username, password, repo_owner, skip_tls, webhook_url, webhook_secret):
     """Forgejo repository and pull request management tool."""
     ctx.ensure_object(dict)
 
@@ -295,6 +301,7 @@ def cli(ctx, forgejo_url, username, password, repo_owner, skip_tls, webhook_url)
     ctx.obj["smee_url"] = config["smee_url"]
     ctx.obj["internal_url"] = config["internal_url"]
     ctx.obj["webhook_url"] = webhook_url
+    ctx.obj["webhook_secret"] = webhook_secret
 
 
 @cli.command("repo")
@@ -317,6 +324,16 @@ def cli(ctx, forgejo_url, username, password, repo_owner, skip_tls, webhook_url)
     default=True,
     help="Create PAC namespace and Repository CR",
 )
+@click.option(
+    "--no-clone",
+    is_flag=True,
+    help="Skip cloning the repository locally",
+)
+@click.option(
+    "--fork-from",
+    default="",
+    help="Fork from OWNER/REPO instead of creating a fresh repository",
+)
 @click.pass_context
 def repo_command(
     ctx,
@@ -327,6 +344,8 @@ def repo_command(
     smee_url,
     internal_url,
     create_pac_cr,
+    no_clone,
+    fork_from,
 ):
     """Create a Forgejo repository and optionally clone it locally."""
     # Get common options from context
@@ -336,8 +355,9 @@ def repo_command(
     repo_owner = ctx.obj["repo_owner"]
     skip_tls = ctx.obj["skip_tls"]
 
-    # Get webhook_url from context (takes precedence over smee_url)
+    # Get webhook_url and webhook_secret from context
     webhook_url = ctx.obj.get("webhook_url", "")
+    webhook_secret = ctx.obj.get("webhook_secret", "")
 
     # Get smee_url and internal_url from context if not provided via CLI/env
     if not smee_url and ctx.obj.get("smee_url"):
@@ -411,28 +431,40 @@ def repo_command(
     if response.status_code == 204:
         click.echo(f"Repository {owner}/{repo} deleted")
 
-    # Create new repository
-    if on_org:
-        create_url = f"{forgejo_url}/api/v1/orgs/{owner}/repos"
+    # Create new repository or fork
+    if fork_from:
+        fork_owner, fork_repo_name = fork_from.split("/", 1)
+        fork_url = f"{forgejo_url}/api/v1/repos/{fork_owner}/{fork_repo_name}/forks"
+        fork_data = {"name": repo}
+        response = requests.post(fork_url, json=fork_data, headers=headers, verify=verify_tls)
+        if response.status_code not in (202, 409):
+            click.echo(
+                f"Error forking repository: {response.status_code} {response.text}",
+                err=True,
+            )
+            sys.exit(1)
     else:
-        create_url = f"{forgejo_url}/api/v1/user/repos"
+        if on_org:
+            create_url = f"{forgejo_url}/api/v1/orgs/{owner}/repos"
+        else:
+            create_url = f"{forgejo_url}/api/v1/user/repos"
 
-    repo_data = {
-        "name": repo,
-        "private": False,
-        "auto_init": True,
-        "description": "This is a repo it's a wonderful thing",
-    }
+        repo_data = {
+            "name": repo,
+            "private": False,
+            "auto_init": True,
+            "description": "This is a repo it's a wonderful thing",
+        }
 
-    response = requests.post(
-        create_url, json=repo_data, headers=headers, verify=verify_tls
-    )
-    if response.status_code not in (201, 409):
-        click.echo(
-            f"Error creating repository: {response.status_code} {response.text}",
-            err=True,
+        response = requests.post(
+            create_url, json=repo_data, headers=headers, verify=verify_tls
         )
-        sys.exit(1)
+        if response.status_code not in (201, 409):
+            click.echo(
+                f"Error creating repository: {response.status_code} {response.text}",
+                err=True,
+            )
+            sys.exit(1)
 
     repo_info = response.json()
     html_url = repo_info.get("html_url", "")
@@ -442,53 +474,57 @@ def repo_command(
 
     # Create webhook if webhook URL or smee URL is provided
     if effective_webhook_url:
-        create_webhook(forgejo_url, headers, owner, repo, effective_webhook_url, verify_tls)
+        create_webhook(
+            forgejo_url, headers, owner, repo, effective_webhook_url, verify_tls, webhook_secret
+        )
 
     namespace = target_ns if target_ns else repo
 
-    if create_pac_cr:
-        create_pac_resources(namespace, repo, html_url, internal_url, token)
+    if create_pac_cr and not fork_from:
+        create_pac_resources(namespace, repo, html_url, internal_url, token, webhook_secret)
 
-    # Build authenticated clone URL
-    parsed = urlparse(clone_url)
-    auth_url = urlunparse(
-        (parsed.scheme, f"git:{password}@{parsed.netloc}", parsed.path, "", "", "")
-    )
+    if not no_clone:
+        # Build authenticated clone URL
+        parsed = urlparse(clone_url)
+        auth_url = urlunparse(
+            (parsed.scheme, f"git:{password}@{parsed.netloc}", parsed.path, "", "", "")
+        )
 
-    # Clone repository
-    local_checkout = local_repo if local_repo else f"/tmp/{repo}"
-    local_path = Path(local_checkout)
+        # Clone repository
+        local_checkout = local_repo if local_repo else f"/tmp/{repo}"
+        local_path = Path(local_checkout)
 
-    if local_path.exists():
-        click.echo(f"Directory {local_checkout} already exists, skipping clone")
+        if local_path.exists():
+            click.echo(f"Directory {local_checkout} already exists, skipping clone")
+            click.echo(f"\nLocal Checkout Directory: {local_checkout}")
+            click.echo(f"Forgejo Repository URL: {html_url}")
+            return
+
+        try:
+            subprocess.run(
+                ["git", "clone", auth_url, local_checkout],
+                check=True,
+                capture_output=True,
+            )
+            click.echo(f"Repository cloned to: {local_checkout}")
+
+            # Create a branch
+            subprocess.run(
+                ["git", "checkout", "-b", "tektonci"],
+                cwd=local_checkout,
+                check=True,
+                capture_output=True,
+            )
+            click.echo("Created branch: tektonci")
+
+        except subprocess.CalledProcessError as e:
+            click.echo(f"Error during git operations: {e}", err=True)
+            if e.stderr:
+                click.echo(e.stderr.decode(), err=True)
+            sys.exit(1)
+
         click.echo(f"\nLocal Checkout Directory: {local_checkout}")
-        click.echo(f"Forgejo Repository URL: {html_url}")
-        return
 
-    try:
-        subprocess.run(
-            ["git", "clone", auth_url, local_checkout],
-            check=True,
-            capture_output=True,
-        )
-        click.echo(f"Repository cloned to: {local_checkout}")
-
-        # Create a branch
-        subprocess.run(
-            ["git", "checkout", "-b", "tektonci"],
-            cwd=local_checkout,
-            check=True,
-            capture_output=True,
-        )
-        click.echo("Created branch: tektonci")
-
-    except subprocess.CalledProcessError as e:
-        click.echo(f"Error during git operations: {e}", err=True)
-        if e.stderr:
-            click.echo(e.stderr.decode(), err=True)
-        sys.exit(1)
-
-    click.echo(f"\nLocal Checkout Directory: {local_checkout}")
     click.echo(f"Forgejo Repository URL: {html_url}")
 
 
@@ -711,6 +747,80 @@ def checkout_command(ctx, repo, destination):
         sys.exit(1)
 
 
+@cli.command("create-user")
+@click.option("--new-username", default="nonadmin", help="Username for the new user")
+@click.option("--new-password", default="nonadmin", help="Password for the new user")
+@click.option(
+    "--new-email", default="nonadmin@localhost", help="Email for the new user"
+)
+@click.pass_context
+def create_user_command(ctx, new_username, new_password, new_email):
+    """Create a non-admin user on Forgejo using admin credentials."""
+    forgejo_url = ctx.obj["forgejo_url"]
+    username = ctx.obj["username"]
+    password = ctx.obj["password"]
+    skip_tls = ctx.obj["skip_tls"]
+
+    # Validate required configuration (no repo_owner needed)
+    missing = []
+    for field in ("forgejo_url", "username", "password"):
+        if not ctx.obj.get(field):
+            missing.append(field)
+    if missing:
+        click.echo(
+            f"Error: Missing required configuration: {', '.join(missing)}", err=True
+        )
+        sys.exit(1)
+
+    forgejo_url = forgejo_url.rstrip("/")
+    verify_tls = not skip_tls
+
+    if skip_tls:
+        warnings.filterwarnings("ignore", message="Unverified HTTPS request")
+
+    auth = (username, password)
+    url = f"{forgejo_url}/api/v1/admin/users"
+    user_data = {
+        "username": new_username,
+        "password": new_password,
+        "email": new_email,
+        "must_change_password": False,
+        "visibility": "public",
+    }
+
+    # Retry loop for service readiness (Forgejo may still be starting)
+    max_retries = 30
+    retry_delay = 5  # seconds
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.post(url, json=user_data, auth=auth, verify=verify_tls)
+            if response.status_code in (503, 502):
+                if attempt < max_retries:
+                    click.echo(f"Forgejo not ready (HTTP {response.status_code}), retrying ({attempt}/{max_retries})...")
+                    time.sleep(retry_delay)
+                    continue
+            break  # Got a non-transient response
+        except requests.exceptions.ConnectionError:
+            if attempt < max_retries:
+                click.echo(f"Connection failed, retrying ({attempt}/{max_retries})...")
+                time.sleep(retry_delay)
+                continue
+            raise
+        except requests.exceptions.RequestException as exc:
+            click.echo(f"Error creating user: {exc}", err=True)
+            sys.exit(1)
+
+    if response.status_code == 201:
+        click.echo(f"User '{new_username}' created successfully")
+    elif response.status_code == 422:
+        click.echo(f"User '{new_username}' already exists")
+    else:
+        click.echo(
+            f"Error creating user: {response.status_code} {response.text}", err=True
+        )
+        sys.exit(1)
+
+
 def create_access_token(forgejo_url, auth, name, verify_tls):
     """Create an access token with all scopes."""
 
@@ -749,16 +859,16 @@ def create_access_token(forgejo_url, auth, name, verify_tls):
     return auth[1]
 
 
-def create_webhook(forgejo_url, headers, owner, repo, hook_url, verify_tls):
+def create_webhook(forgejo_url, headers, owner, repo, hook_url, verify_tls, webhook_secret=""):
     """Create a webhook for the repository."""
     url = f"{forgejo_url}/api/v1/repos/{owner}/{repo}/hooks"
+    config = {"url": hook_url, "content_type": "json"}
+    if webhook_secret:
+        config["secret"] = webhook_secret
     webhook_data = {
         "type": "forgejo",
         "active": True,
-        "config": {
-            "url": hook_url,
-            "content_type": "json",
-        },
+        "config": config,
         "events": ["push", "issue_comment", "pull_request"],
     }
 
@@ -769,7 +879,7 @@ def create_webhook(forgejo_url, headers, owner, repo, hook_url, verify_tls):
         click.echo(f"Warning: Could not create webhook (status {response.status_code})")
 
 
-def create_pac_resources(namespace, repo_name, repo_url, internal_url, token):
+def create_pac_resources(namespace, repo_name, repo_url, internal_url, token, webhook_secret=""):
     """Create PAC namespace, secret, and Repository CR using kubectl."""
 
     click.echo(f"Creating PAC resources in namespace: {namespace}")
@@ -808,17 +918,16 @@ def create_pac_resources(namespace, repo_name, repo_url, internal_url, token):
         capture_output=True,
     )
 
+    secret_args = [
+        "kubectl", "create", "secret", "generic", repo_name,
+        f"--from-literal=token={token}",
+    ]
+    if webhook_secret:
+        secret_args.append(f"--from-literal=webhook-secret={webhook_secret}")
+    secret_args += ["-n", namespace]
+
     result = subprocess.run(
-        [
-            "kubectl",
-            "create",
-            "secret",
-            "generic",
-            repo_name,
-            f"--from-literal=token={token}",
-            "-n",
-            namespace,
-        ],
+        secret_args,
         capture_output=True,
         text=True,
     )
@@ -841,6 +950,12 @@ def create_pac_resources(namespace, repo_name, repo_url, internal_url, token):
         capture_output=True,
     )
 
+    webhook_secret_block = ""
+    if webhook_secret:
+        webhook_secret_block = f"""    webhook_secret:
+      name: {repo_name}
+      key: webhook-secret
+"""
     repository_yaml = f"""apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
@@ -854,7 +969,7 @@ spec:
     secret:
       name: {repo_name}
       key: token
-"""
+{webhook_secret_block}"""
 
     result = subprocess.run(
         ["kubectl", "apply", "-f", "-"],

--- a/startpaac
+++ b/startpaac
@@ -76,9 +76,9 @@ fi
 # NodePort configuration for direct webhook delivery
 PAC_WEBHOOK_NODEPORT=${PAC_WEBHOOK_NODEPORT:-30080}
 if [[ "${USE_NODEPORT_WEBHOOK}" == "true" ]]; then
-  PAAC_WEBHOOK_URL="http://${TARGET_BIND_IP:-127.0.0.1}:${PAC_WEBHOOK_NODEPORT}"
+  PAAC_WEBHOOK_URL=${PAAC_WEBHOOK_URL:-"http://${TARGET_BIND_IP:-127.0.0.1}:${PAC_WEBHOOK_NODEPORT}"}
 else
-  PAAC_WEBHOOK_URL="https://${PAAC}"
+  PAAC_WEBHOOK_URL=${PAAC_WEBHOOK_URL:-"https://${PAAC}"}
 fi
 
 [[ -z ${DOMAIN_NAME} || -z ${TARGET_HOST} || -z ${TARGET_BIND_IP} || -z ${REGISTRY} || -z ${DASHBOARD} || -z ${PAAC} ]] && {
@@ -492,6 +492,53 @@ function install_forgejo() {
   "${SP}"/lib/forgejo/install.sh ${1}
 }
 
+function setup_forgejo_sample() {
+  show_step "Setting up Forgejo sample repository and non-admin user"
+  local protocol="https"
+  local forgejo_url="${protocol}://${FORGE_HOST}"
+  local admin_user="pac"
+  local admin_pass="pac"
+  local sample_user="nonadmin"
+  local sample_pass="nonadmin"
+  local sample_repo="sample"
+
+  # Create non-admin user (authenticates as admin)
+  "${SP}"/misc/forgejo-mng/main.py \
+    --forgejo-url "${forgejo_url}" \
+    --username "${admin_user}" \
+    --password "${admin_pass}" \
+    --repo-owner "${sample_user}" \
+    --skip-tls \
+    create-user \
+    --new-username "${sample_user}" \
+    --new-password "${sample_pass}"
+
+  # Create sample repo under pac admin user first (nonadmin will fork it)
+  "${SP}"/misc/forgejo-mng/main.py \
+    --forgejo-url "${forgejo_url}" \
+    --username "${admin_user}" \
+    --password "${admin_pass}" \
+    --repo-owner "${admin_user}" \
+    --skip-tls \
+    --webhook-url "${PAAC_WEBHOOK_URL}" \
+    --webhook-secret "${PAAC_WEBHOOK_SECRET}" \
+    repo "${sample_repo}" \
+    --no-clone
+
+  # Fork admin repo as nonadmin user
+  "${SP}"/misc/forgejo-mng/main.py \
+    --forgejo-url "${forgejo_url}" \
+    --username "${sample_user}" \
+    --password "${sample_pass}" \
+    --repo-owner "${sample_user}" \
+    --skip-tls \
+    --webhook-url "${PAAC_WEBHOOK_URL}" \
+    --webhook-secret "${PAAC_WEBHOOK_SECRET}" \
+    repo "${sample_repo}" \
+    --fork-from "${admin_user}/${sample_repo}" \
+    --no-clone
+}
+
 function install_postgresql() {
   show_step "Installing PostgreSQL"
   "${SP}"/lib/postgresql/install.sh
@@ -639,7 +686,10 @@ all() {
   }
 
   # Other optional components
-  [[ ${INSTALL_FORGE} == "true" ]] && run_with_hooks install-forgejo install_forgejo ${FORGE_HOST}
+  [[ ${INSTALL_FORGE} == "true" ]] && {
+    run_with_hooks install-forgejo install_forgejo ${FORGE_HOST}
+    run_with_hooks setup-forgejo-sample setup_forgejo_sample
+  }
   [[ ${INSTALL_POSTGRESQL} == "true" ]] && run_with_hooks install-postgresql install_postgresql
   [[ -n ${INSTALL_CUSTOM_OBJECT:-} && ${INSTALL_CUSTOM_OBJECT_ENABLED} == "true" ]] && run_with_hooks install-custom-objects install_custom_objects
 
@@ -894,6 +944,7 @@ function parse_args() {
     interactive,
     reset-preferences,
     ci,
+    setup-forgejo-sample,
     kind
     " -- "$@")
   #shellcheck disable=SC2181
@@ -910,6 +961,11 @@ function parse_args() {
 
     -g | --install-forgejo) # Install Forgejo
       install_forgejo ${FORGE_HOST}
+      setup_forgejo_sample
+      exit
+      ;;
+    --setup-forgejo-sample) # Setup sample Forgejo user and repo
+      setup_forgejo_sample
       exit
       ;;
     --debug-image) # use a debug image to apply KO images

--- a/startpaac
+++ b/startpaac
@@ -32,7 +32,7 @@ fi
 
 TARGET_HOST=${TARGET_HOST:-}
 DOMAIN_NAME=${DOMAIN_NAME:-""}
-PAAC_DOMAIN=${PAAC_DOMAIN:-""}
+PAC_DOMAIN=${PAC_DOMAIN:-""}
 PAAC=${PAAC:-""}
 REGISTRY=${REGISTRY:-""}
 KO_EXTRA_FLAGS=${KO_EXTRA_FLAGS:-""}
@@ -60,13 +60,13 @@ export CI_MODE
 if [[ ${TARGET_HOST} == local ]]; then
   KO_EXTRA_FLAGS=(--insecure-registry)
   DOMAIN_NAME=${TARGET_HOST}
-  # Allow domain override via PAAC_DOMAIN for CI compatibility
-  PAAC_DOMAIN=${PAAC_DOMAIN:-"127.0.0.1.nip.io"}
-  REGISTRY=registry.${PAAC_DOMAIN}
-  FORGE_HOST=gitea.${PAAC_DOMAIN}
+  # Allow domain override via PAC_DOMAIN for CI compatibility
+  PAC_DOMAIN=${PAC_DOMAIN:-"127.0.0.1.nip.io"}
+  REGISTRY=registry.${PAC_DOMAIN}
+  FORGE_HOST=gitea.${PAC_DOMAIN}
   TARGET_BIND_IP=127.0.0.1
-  DASHBOARD=dashboard.${PAAC_DOMAIN}
-  PAAC=paac.${PAAC_DOMAIN}
+  DASHBOARD=dashboard.${PAC_DOMAIN}
+  PAAC=paac.${PAC_DOMAIN}
   # Default to NodePort webhook for local mode
   USE_NODEPORT_WEBHOOK=${USE_NODEPORT_WEBHOOK:-true}
 else
@@ -76,16 +76,17 @@ fi
 # NodePort configuration for direct webhook delivery
 PAC_WEBHOOK_NODEPORT=${PAC_WEBHOOK_NODEPORT:-30080}
 if [[ "${USE_NODEPORT_WEBHOOK}" == "true" ]]; then
-  PAAC_WEBHOOK_URL=${PAAC_WEBHOOK_URL:-"http://${TARGET_BIND_IP:-127.0.0.1}:${PAC_WEBHOOK_NODEPORT}"}
+  PAC_WEB_URL=${PAC_WEB_URL:-"http://${TARGET_BIND_IP:-127.0.0.1}:${PAC_WEBHOOK_NODEPORT}"}
 else
-  PAAC_WEBHOOK_URL=${PAAC_WEBHOOK_URL:-"https://${PAAC}"}
+  PAC_WEB_URL=${PAC_WEB_URL:-"https://${PAAC}"}
 fi
+PAC_WEB_SECRET=${PAC_WEB_SECRET:-""}
 
 [[ -z ${DOMAIN_NAME} || -z ${TARGET_HOST} || -z ${TARGET_BIND_IP} || -z ${REGISTRY} || -z ${DASHBOARD} || -z ${PAAC} ]] && {
   echo "Need to set DOMAIN_NAME, TARGET_HOST, TARGET_BIND_IP, REGISTRY, DASHBOARD and PAAC in your $HOME/.config/startpaac/config"
   exit 1
 }
-[[ -n ${DOMAIN_NAME} && -z ${PAAC_DOMAIN} ]] && PAAC_DOMAIN=${DOMAIN_NAME}
+[[ -n ${DOMAIN_NAME} && -z ${PAC_DOMAIN} ]] && PAC_DOMAIN=${DOMAIN_NAME}
 
 TMPFILE=$(mktemp /tmp/.startpaac.XXXXXX)
 # shellcheck disable=SC2317
@@ -118,7 +119,7 @@ FORGE_HOST: ${protocol}://${FORGE_HOST}
 DASHBOARD: ${protocol}://${DASHBOARD}
 EOF
   if [[ "${USE_NODEPORT_WEBHOOK}" == "true" ]]; then
-    echo "PAAC WEBHOOK: ${PAAC_WEBHOOK_URL} (NodePort - no gosmee needed)"
+    echo "PAAC WEBHOOK: ${PAC_WEB_URL} (NodePort - no gosmee needed)"
   else
     cat <<EOF
   GOSMEE:
@@ -520,8 +521,8 @@ function setup_forgejo_sample() {
     --password "${admin_pass}" \
     --repo-owner "${admin_user}" \
     --skip-tls \
-    --webhook-url "${PAAC_WEBHOOK_URL}" \
-    --webhook-secret "${PAAC_WEBHOOK_SECRET}" \
+    --webhook-url "${PAC_WEB_URL}" \
+    --webhook-secret "${PAC_WEB_SECRET}" \
     repo "${sample_repo}" \
     --no-clone
 
@@ -532,8 +533,8 @@ function setup_forgejo_sample() {
     --password "${sample_pass}" \
     --repo-owner "${sample_user}" \
     --skip-tls \
-    --webhook-url "${PAAC_WEBHOOK_URL}" \
-    --webhook-secret "${PAAC_WEBHOOK_SECRET}" \
+    --webhook-url "${PAC_WEB_URL}" \
+    --webhook-secret "${PAC_WEB_SECRET}" \
     repo "${sample_repo}" \
     --fork-from "${admin_user}/${sample_repo}" \
     --no-clone
@@ -581,7 +582,7 @@ function install_github_second_ctrl() {
   local pac_controller_label="ghe" pac_controller_smee_url
   local pac_controller_secret=${pac_controller_label}-secret
   local pac_controller_configmap=${pac_controller_label}-configmap
-  local gosmeeTargetURL=${pac_controller_label}.${PAAC_DOMAIN}
+  local gosmeeTargetURL=${pac_controller_label}.${PAC_DOMAIN}
   show_step "Installing GHE second controller for github"
 
   [[ -z ${PAC_PASS_SECOND_FOLDER:-} && -z ${PAC_SECOND_SECRET_FOLDER:-} ]] && {

--- a/startpaac
+++ b/startpaac
@@ -33,7 +33,7 @@ fi
 TARGET_HOST=${TARGET_HOST:-}
 DOMAIN_NAME=${DOMAIN_NAME:-""}
 PAC_DOMAIN=${PAC_DOMAIN:-""}
-PAAC=${PAAC:-""}
+PAC=${PAC:-""}
 REGISTRY=${REGISTRY:-""}
 KO_EXTRA_FLAGS=${KO_EXTRA_FLAGS:-""}
 FORGE_HOST=${FORGE_HOST:-""}
@@ -66,7 +66,7 @@ if [[ ${TARGET_HOST} == local ]]; then
   FORGE_HOST=gitea.${PAC_DOMAIN}
   TARGET_BIND_IP=127.0.0.1
   DASHBOARD=dashboard.${PAC_DOMAIN}
-  PAAC=paac.${PAC_DOMAIN}
+  PAC=paac.${PAC_DOMAIN}
   # Default to NodePort webhook for local mode
   USE_NODEPORT_WEBHOOK=${USE_NODEPORT_WEBHOOK:-true}
 else
@@ -78,12 +78,12 @@ PAC_WEBHOOK_NODEPORT=${PAC_WEBHOOK_NODEPORT:-30080}
 if [[ "${USE_NODEPORT_WEBHOOK}" == "true" ]]; then
   PAC_WEB_URL=${PAC_WEB_URL:-"http://${TARGET_BIND_IP:-127.0.0.1}:${PAC_WEBHOOK_NODEPORT}"}
 else
-  PAC_WEB_URL=${PAC_WEB_URL:-"https://${PAAC}"}
+  PAC_WEB_URL=${PAC_WEB_URL:-"https://${PAC}"}
 fi
 PAC_WEB_SECRET=${PAC_WEB_SECRET:-""}
 
-[[ -z ${DOMAIN_NAME} || -z ${TARGET_HOST} || -z ${TARGET_BIND_IP} || -z ${REGISTRY} || -z ${DASHBOARD} || -z ${PAAC} ]] && {
-  echo "Need to set DOMAIN_NAME, TARGET_HOST, TARGET_BIND_IP, REGISTRY, DASHBOARD and PAAC in your $HOME/.config/startpaac/config"
+[[ -z ${DOMAIN_NAME} || -z ${TARGET_HOST} || -z ${TARGET_BIND_IP} || -z ${REGISTRY} || -z ${DASHBOARD} || -z ${PAC} ]] && {
+  echo "Need to set DOMAIN_NAME, TARGET_HOST, TARGET_BIND_IP, REGISTRY, DASHBOARD and PAC in your $HOME/.config/startpaac/config"
   exit 1
 }
 [[ -n ${DOMAIN_NAME} && -z ${PAC_DOMAIN} ]] && PAC_DOMAIN=${DOMAIN_NAME}
@@ -113,17 +113,17 @@ Using configuration on ${TARGET_HOST}:
 
 DOMAIN_NAME: ${DOMAIN_NAME},
 TARGET_BIND_IP: ${TARGET_BIND_IP}
-PAAC: ${protocol}://${PAAC}
+PAC: ${protocol}://${PAC}
 REGISTRY: ${protocol}://${REGISTRY}
 FORGE_HOST: ${protocol}://${FORGE_HOST}
 DASHBOARD: ${protocol}://${DASHBOARD}
 EOF
   if [[ "${USE_NODEPORT_WEBHOOK}" == "true" ]]; then
-    echo "PAAC WEBHOOK: ${PAC_WEB_URL} (NodePort - no gosmee needed)"
+    echo "PAC WEBHOOK: ${PAC_WEB_URL} (NodePort - no gosmee needed)"
   else
     cat <<EOF
   GOSMEE:
-  gosmee client --saveDir /tmp/replay ${smee_url} ${protocol}://${PAAC}
+  gosmee client --saveDir /tmp/replay ${smee_url} ${protocol}://${PAC}
 EOF
   fi
 }
@@ -399,7 +399,7 @@ configure_pac() {
   show_step "Configuring PAC"
   [[ -n ${1:-} && ${1} == "--no-ingress" ]] && no_ingress=yes
   if [[ -z ${no_ingress} ]]; then
-    create_ingress pipelines-as-code pipelines-as-code-controller "${PAAC}" 8080
+    create_ingress pipelines-as-code pipelines-as-code-controller "${PAC}" 8080
   fi
   patch_configmap "${PAC_CONTROLLER_TARGET_NS}"
 


### PR DESCRIPTION
This pull request introduces a comprehensive renaming of the project from "StartPAAC" to "StartPAC" and updates related environment variables and documentation accordingly. Additionally, it enhances the `misc/forgejo-mng/main.py` management tool by adding new options for repository and user management, as well as improved webhook and secret handling for Pipelines as Code (PAC). The changes improve clarity, usability, and security, while ensuring consistency across scripts, documentation, and configuration.
