### PR TITLE
refactor: remove custom CRD installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,6 @@ For non-interactive installation of everything, use the `-a` option.
 - `--install-tekton`        Install Tekton
 - `--install-triggers`      Install Tekton Triggers
 - `--install-chains`        Install Tekton Chains
-- `--install-custom-crds`   Install custom CRDs
 - `--redeploy-kind`         Redeploy Kind
 - `--scale-down`            Scale down a component (controller, watcher, webhook)
 - `--second-secret=SECRET`  Pass name for the second controller secret
@@ -429,12 +428,6 @@ Clear your saved preferences:
 
 ```sh
 ./startpaac --install-chains
-```
-
-### Install Custom CRDs
-
-```sh
-./startpaac --install-custom-crds
 ```
 
 ### Deploy a Specific Component

--- a/misc/_startpaac
+++ b/misc/_startpaac
@@ -59,7 +59,6 @@ _arguments -C \
     '--second-secret[Set the secret for second controller]:secret:->pass_profiles' \
     '--configure-pac[Configure PAC]' \
     '--show-config[Show config]' \
-    '--install-custom-crds[Install custom CRDs]' \
     '*:argument:->args' && ret=0
 
 case $state in

--- a/startpaac
+++ b/startpaac
@@ -927,7 +927,6 @@ function parse_args() {
     deploy-component:,
     github-second-ctrl,
     help,
-    install-custom-crds,
     install-dashboard,
     install-forgejo,
     install-nginx,
@@ -1069,10 +1068,6 @@ function parse_args() {
     -c | --deploy-component) # Install a specific component
       install_pac "$2"
       shift
-      exit
-      ;;
-    --install-custom-crds) # Install custom crds
-      install_custom_crds
       exit
       ;;
     --configure-pac) # Configure PAC


### PR DESCRIPTION
Deleted the `--install-custom-crds` flag and its associated logic from the CLI and documentation as the functionality is no longer required.