### PR TITLE
refactor: restructure documentation and less sloppy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout pipelines-as-code repository (required dependency)
         uses: actions/checkout@v4
         with:
-          repository: openshift-pipelines/pipelines-as-code
+          repository: tektoncd/pipelines-as-code
           path: pipelines-as-code
 
       - name: Set up Helm

--- a/README.md
+++ b/README.md
@@ -1,77 +1,14 @@
-# 🚀 StartPAC - All in one setup for Pipelines as Code on Kind
+# startpaac
+
+Set up [Pipelines-as-Code](https://pipelinesascode.com) on a local Kind cluster for development.
 
 [![ShellCheck](https://github.com/chmouel/startpaac/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/chmouel/startpaac/actions/workflows/shellcheck.yml)
 
-`startpaac` is a script to set up and configure [Pipelines as Code (PAC)](https://pipelinesascode.com) on a
-Kubernetes cluster using Kind. It features an interactive menu to select which
-components to install, with preferences that can be saved for future runs.
+## Quick start
 
-> **What is Pipelines as Code?** Pipelines as Code is a Tekton-based CI/CD system that allows you to define your pipelines as code in your source repository, triggered by GitHub/GitLab events.
+This is meant for local development only.
 
-**Core components** (always installed):
-
-- Kind cluster
-- Nginx ingress gateway
-- Docker registry to push images to
-- Tekton Pipelines latest release
-
-**Optional components** (choose via interactive menu):
-
-- Pipelines-as-Code (PAC) using ko from your local revision
-- Tekton Dashboard
-- Tekton Triggers
-- Tekton Chains
-- Forgejo for local dev
-- PostgreSQL
-- Custom Kubernetes objects
-- GitHub Second Controller
-
-## System Requirements
-
-**Minimum**:
-
-- 4 CPU cores
-- 8GB RAM
-- 20GB available disk space
-
-**Recommended**:
-
-- 8 CPU cores
-- 16GB RAM
-- 50GB available disk space
-
-## Prerequisites
-
-The following tools are required. Install them before running `startpaac`:
-
-- [Docker](https://docs.docker.com/get-docker/) >= 20.10 - Container runtime (tested with Docker, Podman may work but untested)
-- [Kind](https://kind.sigs.k8s.io/) >= 0.20.0 - Kubernetes in Docker
-- [Helm](https://helm.sh/) >= 3.10 - Kubernetes package manager
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= 1.24 - Kubernetes command-line tool
-- [ko](https://github.com/google/ko) >= 0.14 - Build and deploy Go applications on Kubernetes
-- [gum](https://github.com/charmbracelet/gum) >= 0.11 - Interactive component selection menus
-- [jq](https://stedolan.github.io/jq/) >= 1.6 - JSON processor for preferences management
-- [minica](https://github.com/jsha/minica) - Self-signed certificate generation
-- [pass](https://www.passwordstore.org/) (optional) - Password manager for secrets
-- GNU Tools (macOS/BSD users: install from homebrew - [coreutils](https://formulae.brew.sh/formula/coreutils), [gnu-sed](https://formulae.brew.sh/formula/gnu-sed#default))
-
-## Security Notice
-
-⚠️ **This tool is designed for local development environments only.**
-
-- Default passwords in the values.yaml files are **weak and for development only**
-- Self-signed TLS certificates are generated automatically
-- Secrets can be stored in plain text files (use `pass` for better security)
-- **DO NOT use this setup in production environments**
-- Review and change all default credentials in `lib/*/values.yaml` if deploying anywhere accessible
-
-For production deployments, please refer to the [Pipelines as Code production installation guide](https://pipelinesascode.com/docs/installation/overview/).
-
-
-## Getting Started
-
-Execute or adapt the following, adjust the path of the PAC folder where you
-have checked out pipelines-as-code:
+Create a config file:
 
 ```shell
 mkdir -p $HOME/.config/startpaac
@@ -82,457 +19,98 @@ PAC_SECRET_FOLDER=~/secrets
 EOF
 ```
 
-Create your GitHub application and grab all the info needed and put them in
-each secret file for example:
+Create your [GitHub App](https://pipelinesascode.com/docs/install/github_apps/) and store the credentials:
 
 ```shell
 mkdir -p ~/secrets
-for i in github-application-id github-private-key smee webhook.secret;do
-  echo "Editing $i file"
+for i in github-application-id github-private-key smee webhook.secret; do
   ${EDITOR:-vi} ~/secrets/$i
 done
 ```
 
-execute to interactively select and deploy components:
+Run the interactive installer:
 
 ```shell
 ./startpaac
 ```
 
-This will present an interactive menu where you can choose which components to install. For a non-interactive install of everything, use:
+## What gets installed
+
+**Core** (always):
+Kind cluster, Nginx ingress, Docker registry, Tekton Pipelines
+
+**Optional** (selected via menu):
+PAC (built from local source with ko), Tekton Dashboard, Tekton Triggers, Tekton Chains, Forgejo, PostgreSQL, GitHub second controller
+
+## Common usage
 
 ```shell
-./startpaac -a
+./startpaac              # interactive install (or uses saved preferences)
+./startpaac -a           # install everything non-interactively
+./startpaac -p           # redeploy PAC from source
+./startpaac -c controller  # redeploy a single component (controller/watcher/webhook)
+./startpaac --menu       # force the interactive menu
+./startpaac --stop-kind  # tear down the cluster
 ```
 
-if you need to deploy a change you made to your code to the local registry you
-do:
+Configure PAC on an existing cluster (e.g. OpenShift):
 
-```bash
-startpaac -p
+```shell
+./startpaac --configure-pac-target $KUBECONFIG $TARGET_NAMESPACE $SECRET_FOLDER
 ```
 
-this has redeployed everything, if you only want to redeploy the controller you can do:
+## Options
 
-```bash
-startpaac -c controller # same goes for watcher or webhook
-```
-
-if you want to spin down the kind cluster you can do:
-
-```bash
-startpaac --stop-kind
-```
-
-if you have an existing cluster with pac installed (for example openshift) you
-can configure paac directly there:
-
-```bash
-startpaac --configure-pac-target $KUBECONFIG $TARGET_NAMESPACE $DIRECTORY_OR_PASS_FOLDER
-```
-
--The KUBECONFIG is the kubeconfig to use to connect to your cluster.
--The `$TARGET_NAMESPACE` is the namespace where pac is installed (for example
- openshift-pipelines if configured with operator).
--The `$DIRECTORY_OR_PASS_FOLDER` is the secret folder with the same structure as documented
- [earlier](#getting-started) but this can be a password store folder too.
-
-## Interactive Component Selection
-
-When running `startpaac` without any arguments, you'll be presented with an interactive menu to select which optional components to install:
-
-```bash
-./startpaac
-```
-
-The menu allows you to choose from:
-
-- **Pipelines-as-Code (PAC)** - Install and configure PAC (default: on)
-- **Tekton Triggers** - Event triggering for Tekton
-- **Tekton Chains** - Supply chain security for Tekton
-- **Tekton Dashboard** - Web UI for Tekton (default: on)
-- **Forgejo** - Git forge for local development (default: on)
-- **PostgreSQL** - Database for PAC
-- **Custom Objects** - Install custom Kubernetes objects (only shown if `INSTALL_CUSTOM_OBJECT` is configured)
-- **GitHub Second Controller** - Additional controller for GitHub (only shown if secrets are configured)
-
-**Core components** (Kind, Nginx, Registry, Tekton Pipelines) are always installed.
-
-After making your selections, you'll be asked if you want to save your preferences for future runs. Preferences are stored in `~/.config/startpaac/preferences.json`.
-
-### Managing Preferences
-
-```bash
-# Force interactive menu even if preferences exist
-./startpaac --menu
-
-# Reset saved preferences
-./startpaac --reset-preferences
-```
-
-On subsequent runs, if you have saved preferences, the script will automatically use them without showing the menu. You can always override this with `--menu` or clear preferences with `--reset-preferences`.
-
-### Preferences File Format
-
-Preferences are stored as JSON in `~/.config/startpaac/preferences.json`:
-
-```json
-{
-  "pac": true,
-  "tekton_triggers": false,
-  "tekton_chains": false,
-  "tekton_dashboard": true,
-  "forgejo": true,
-  "postgresql": false,
-  "custom_objects": false,
-  "github_second_ctrl": false
-}
-```
+| Flag | Description |
+|------|-------------|
+| `-a, --all` | Install everything |
+| `-A, --all-but-kind` | Install everything but Kind |
+| `-i, --menu, --interactive` | Force interactive component selection |
+| `-R, --reset-preferences` | Reset saved component preferences |
+| `-k, --kind` | (Re)install Kind |
+| `-g, --install-forge` | Install Forgejo |
+| `-c, --deploy-component` | Deploy a component (controller, watcher, webhook) |
+| `-p, --install-paac` | Deploy and configure PAC |
+| `-s, --sync-kubeconfig` | Sync kubeconfig from remote host |
+| `-G, --start-user-gosmee` | Start gosmee locally |
+| `-S, --github-second-ctrl` | Deploy second GitHub controller |
+| `--install-nginx` | Install Nginx |
+| `--install-dashboard` | Install Tekton Dashboard |
+| `--install-tekton` | Install Tekton |
+| `--install-triggers` | Install Tekton Triggers |
+| `--install-chains` | Install Tekton Chains |
+| `--redeploy-kind` | Redeploy Kind |
+| `--scale-down` | Scale down a component |
+| `--stop-kind` | Stop Kind |
+| `--debug-image` | Use debug image for PAC controller |
+| `--show-config` | Show PAC configuration |
+| `--apply-non-root` | Apply non-root config to PAC controller |
+| `-h, --help` | Show help |
 
 ## Configuration
 
-Create a configuration file at `$HOME/.config/startpaac/config` with the following content:
-(this will be auto created by paac if you don't have one)
+Minimal config in `~/.config/startpaac/config`:
 
-## Full Configuration
-
-```bash
-# PAC_DIR is the path to the pipelines-as-code directory, it will try to detect
-# it otherwise
-# PAC_DIR=~/path/to/pipelines-as-code
-#
-# PAC_PASS_SECRET_FOLDER is the path to a folder in https://passwordstore.org/
-# where you have your pac secrets. The folder contains those keys:
-# github/apps/my-app
-# ├── github-application-id
-# ├── github-private-key
-# ├── smee
-# └── webhook.secret
-# github-application-id and github-private-key are the github application id and private key when you create your github app
-# smee is the smee.io or https://hook.pipelinesascode.com generated webhook URL as set in your github apps.
-# webhook.secret is the shared secret as set in your github apps.
-# PAC_PASS_SECRET_FOLDER=github/apps/my-app
-#
-# PAC_SECRET_FOLDER is an alternative to PASS_SECRET_FOLDER where you have your
-# pac secrets in plain text. The folder has the same structure as the
-# PASS_SECRET_FOLDER the only difference is that the files are in plain text.
-#
-# PAC_SECRET_FOLDER=~/path/to/secrets
-#
-# TARGET_HOST is your vm where kind will be running, you need to have kind working there
-# set as local and unset all other variable to have it running on your local VM
-# TARGET_HOST=my.vm.lan
-#
-# KO_EXTRA_FLAGS are the extra flags to pass to ko
-#
-# KO_EXTRA_FLAGS=() # extra ko flags for example --platform linux/arm64 --insecure-registry
-## Hosts (not needed if TARGET_HOST is set to local)
-# setup a wildcard dns *.lan.mydomain.com to go to your TARGET_HOST vm
-# tips: if you don't want to install a dns server you can simply use
-# https://nextdns.io to let you create wildcard dns for your local network.
-#
-# DOMAIN_NAME=lan.mydomain.com
-# PAC=paac.${DOMAIN_NAME}
-# REGISTRY=registry.${DOMAIN_NAME}
-# FORGE_HOST=gitea.${DOMAIN_NAME}
-# DASHBOARD=dashboard.${DASHBOARD}
-#
-# Example:
-# TARGET_HOST=civuole.lan
-# KO_EXTRA_FLAGS=(--insecure-registry --platform linux/arm64)
-# DOMAIN_NAME=vm.lan
-# PAC=paac.${DOMAIN_NAME}
-# REGISTRY=registry.${DOMAIN_NAME}
-# FORGE_HOST=gitea.${DOMAIN_NAME}
-# TARGET_BIND_IP=192.168.1.5
-# TARGET_BIND_IP=192.168.1.5,10.0.0.5 # Comma-separated for multiple IPs
-# DASHBOARD=dashboard.${DOMAIN_NAME}
-# PAC_DIR=$GOPATH/src/github.com/openshift-pipelines/pac/main
+```shell
+TARGET_HOST=local
+PAC_DIR=~/path/to/pipelines-as-code
+PAC_SECRET_FOLDER=~/secrets
 ```
 
-You can have an alternative config file with the `STARTPAC_CONFIG_FILE`
-environment variable.
+See [docs/configuration.md](docs/configuration.md) for the full reference (remote VM setup, secrets management, hooks, PostgreSQL, preferences).
 
-## PostgreSQL Configuration
+## Prerequisites
 
-You can configure the PostgreSQL connection details in the `values.yaml` file
-located in `lib/postgresql/values.yaml`. The following parameters are available
-under `global.postgresql.auth`:
+docker, kind, helm, kubectl, ko, gum, jq, minica
 
-- `username`: The PostgreSQL username.
-- `password`: The PostgreSQL password.
-- `database`: The PostgreSQL database name.
+Optional: [pass](https://www.passwordstore.org/) for secrets management
 
-If you want to customize the PostgreSQL configuration, you can modify the
-`lib/postgresql/values.yaml` file. For example:
+macOS users: install [coreutils](https://formulae.brew.sh/formula/coreutils) and [gnu-sed](https://formulae.brew.sh/formula/gnu-sed) from Homebrew.
 
-```yaml
-global:
-  postgresql:
-    auth:
-      username: "myuser"
-      password: "mypassword"
-      database: "mydatabase"
-```
+## More
 
-## Secrets Management
-
-### Using `pass`
-
-If you prefer to manage your secrets using `pass`, set the
-`PAC_PASS_SECRET_FOLDER` variable in your configuration file to the path of
-your secrets folder in `pass`. The folder should contain the following files:
-
-- `github-application-id`
-- `github-private-key`
-- `smee`
-- `webhook.secret`
-
-Example structure:
-
-```console
-github/apps/my-app
-├── github-application-id
-├── github-private-key
-├── smee
-└── webhook.secret
-```
-
-### Using Plain Text
-
-Alternatively, you can store your secrets in plain text files. Set the
-`PAC_SECRET_FOLDER` variable in your configuration file to the path of your
-secrets folder. The folder should have the same structure as the `pass` folder,
-but the files should be in plain text.
-
-Example structure:
-
-```console
-~/path/to/secrets
-├── github-application-id
-├── github-private-key
-├── smee
-└── webhook.secret
-```
-
-## Usage
-
-Run the script with the desired options:
-
-```sh
-./startpaac [options]
-```
-
-When run without arguments, the script presents an interactive menu to select components. On first run, you can save your preferences which will be used automatically on subsequent runs.
-
-For non-interactive installation of everything, use the `-a` option.
-
-### Options
-
-- `-a|--all`                Install everything (non-interactive)
-- `-A|--all-but-kind`       Install everything but kind
-- `-i|--menu|--interactive` Force interactive component selection menu
-- `-R|--reset-preferences`  Reset saved component preferences
-- `-k|--kind`               (Re)Install Kind
-- `-g|--install-forge`      Install Forgejo
-- `-c|--deploy-component`  Deploy a component (controller, watcher, webhook)
-- `-p|--install-paac`       Deploy and configure PAC
-- `-h|--help`               Show help message
-- `-s|--sync-kubeconfig`    Sync kubeconfig from the remote host
-- `-G|--start-user-gosmee`  Start gosmee locally for user $USER
-- `-S|--github-second-ctrl` Deploy second controller for GitHub
-- `--install-nginx`         Install Nginx
-- `--install-dashboard`     Install Tekton dashboard
-- `--install-tekton`        Install Tekton
-- `--install-triggers`      Install Tekton Triggers
-- `--install-chains`        Install Tekton Chains
-- `--redeploy-kind`         Redeploy Kind
-- `--scale-down`            Scale down a component (controller, watcher, webhook)
-- `--second-secret=SECRET`  Pass name for the second controller secret
-- `--stop-kind`             Stop Kind
-
-## Examples
-
-### Interactive Installation (Recommended for First Time)
-
-Run without arguments to get an interactive menu:
-
-```sh
-./startpaac
-```
-
-This will:
-
-1. Show you the current configuration
-2. Present a multi-select menu of optional components
-3. Ask if you want to save your preferences
-4. Show a summary of what will be installed
-5. Ask for final confirmation before proceeding
-
-### Install Everything (Non-Interactive)
-
-```sh
-./startpaac --all
-```
-
-### Use Saved Preferences
-
-After saving preferences once, simply run:
-
-```sh
-./startpaac
-```
-
-It will use your saved preferences without showing the menu.
-
-### Change Component Selection
-
-Force the menu to appear even with saved preferences:
-
-```sh
-./startpaac --menu
-```
-
-### Reset to Defaults
-
-Clear your saved preferences:
-
-```sh
-./startpaac --reset-preferences
-```
-
-### Install PAC and Configure
-
-```sh
-./startpaac --install-paac
-```
-
-### Install Nginx
-
-```sh
-./startpaac --install-nginx
-```
-
-### Install Tekton
-
-```sh
-./startpaac --install-tekton
-```
-
-### Install Tekton Triggers
-
-```sh
-./startpaac --install-triggers
-```
-
-### Install Tekton Chains
-
-```sh
-./startpaac --install-chains
-```
-
-### Deploy a Specific Component
-
-```sh
-./startpaac --deploy-component controller
-```
-
-### Sync Kubeconfig from Remote Host
-
-```sh
-./startpaac --sync-kubeconfig
-```
-
-### Start User Gosmee
-
-```sh
-./startpaac --start-user-gosmee
-```
-
-it will try to start gosmee for the user if you have a systemd user one, or
-give you the command line to start it.
-
-### Deploy Second Controller for GitHub
-
-```sh
-./startpaac --github-second-ctrl
-```
-
-you need the `PAC_PASS_SECOND_FOLDER` which is the same
-`PAC_PASS_SECRET_FOLDER` but for a second controller to use.
-
-### PAC Installation Configuration
-
-You can configure the PAC installation with the following options:
-
-- `--debug-image`: Use a debug image for the PAC controller.
-- `--show-config`: Show the PAC configuration.
-- `--apply-non-root`: Apply non-root configuration to the PAC controller.
-
-## Hooks
-
-startpaac supports hooks — executable scripts that run automatically at defined
-points in the installation flow. This lets you customize the process (e.g.,
-apply extra K8s resources after Tekton installs, patch configs before PAC
-deploys) without forking or running scripts manually.
-
-### Hook Directory
-
-Hooks are discovered from `~/.config/startpaac/hooks/` (override via the
-`HOOKS_DIR` environment variable).
-
-### Naming Convention
-
-Hook files are named `pre-<component>` or `post-<component>`. For example:
-
-- `pre-install-tekton` — runs before Tekton is installed
-- `post-configure-pac` — runs after PAC is configured
-
-Available hook points: `all`, `sync-kubeconfig`, `install-nginx`,
-`install-registry`, `install-tekton`, `install-triggers`, `install-chains`,
-`install-dashboard`, `install-pac`, `configure-pac`,
-`configure-pac-custom-certs`, `patch-pac-service-nodeport`, `install-forgejo`,
-`install-postgresql`, `install-custom-objects`, `install-github-second-ctrl`.
-
-### Format
-
-A hook can be either:
-
-- A single executable file (e.g., `~/.config/startpaac/hooks/post-install-tekton`)
-- A directory of executable files, run in sorted order (e.g.,
-  `~/.config/startpaac/hooks/post-install-tekton/01-apply-extras`,
-  `~/.config/startpaac/hooks/post-install-tekton/02-patch-config`)
-
-### Environment
-
-All existing environment variables are inherited (`KUBECONFIG`, `TARGET_HOST`,
-`DOMAIN_NAME`, `PAC_DIR`, `CI_MODE`, etc.). Additionally,
-`STARTPAC_HOOK_NAME` is exported with the current hook name.
-
-### Failure Behavior
-
-A non-zero exit from any hook script aborts the startpaac run.
-
-### Example
-
-```bash
-mkdir -p ~/.config/startpaac/hooks
-cat > ~/.config/startpaac/hooks/post-install-tekton <<'EOF'
-#!/bin/bash
-echo "Tekton installed — applying custom resources"
-kubectl apply -f ~/my-extra-resources/
-EOF
-chmod +x ~/.config/startpaac/hooks/post-install-tekton
-```
-
-## ZSH Completion
-
-There is a [ZSH completion script](./misc/_startpaac) that can get installed in your
-
-path for completion.
+- [Configuration reference](docs/configuration.md)
+- [Architecture](docs/architecture.md)
+- [ZSH completion](misc/_startpaac)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-
-## Author
-
-OpenShift Pipelines Team

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create a config file:
 mkdir -p $HOME/.config/startpaac
 cat <<EOF > $HOME/.config/startpaac/config
 TARGET_HOST=local
-PAC_DIR=~/go/src/github.com/openshift-pipelines/pipelines-as-code
+PAC_DIR=~/go/src/github.com/tektoncd/pipelines-as-code
 PAC_SECRET_FOLDER=~/secrets
 EOF
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -427,6 +427,6 @@ INSTALL_CUSTOM_OBJECT_ENABLED=true
 ## Related Documentation
 
 - [README.md](../README.md) - User guide and getting started
-- [TROUBLESHOOTING.md](../TROUBLESHOOTING.md) - Common issues and solutions
+- [configuration.md](configuration.md) - Full configuration reference
 - [Pipelines as Code Docs](https://pipelinesascode.com/docs/) - PAC documentation
 - [Tekton Docs](https://tekton.dev/docs/) - Tekton documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,144 @@
+# Configuration reference
+
+## Config file
+
+Located at `~/.config/startpaac/config` (override with `STARTPAC_CONFIG_FILE` env var).
+
+```bash
+# Path to your pipelines-as-code checkout (auto-detected if unset)
+PAC_DIR=~/go/src/github.com/openshift-pipelines/pipelines-as-code
+
+# Secrets via password-store (pass)
+# Folder structure: github-application-id, github-private-key, smee, webhook.secret
+PAC_PASS_SECRET_FOLDER=github/apps/my-app
+
+# Or secrets as plain text files (same structure as above)
+PAC_SECRET_FOLDER=~/path/to/secrets
+
+# Where Kind runs: "local" or a remote hostname
+TARGET_HOST=local
+
+# Extra flags for ko
+KO_EXTRA_FLAGS=() # e.g. --platform linux/arm64 --insecure-registry
+
+## Remote VM setup (not needed when TARGET_HOST=local)
+# Set up a wildcard DNS *.lan.mydomain.com pointing to your TARGET_HOST.
+# Tip: https://nextdns.io lets you create wildcard DNS for local networks.
+DOMAIN_NAME=lan.mydomain.com
+PAC=paac.${DOMAIN_NAME}
+REGISTRY=registry.${DOMAIN_NAME}
+FORGE_HOST=gitea.${DOMAIN_NAME}
+DASHBOARD=dashboard.${DOMAIN_NAME}
+TARGET_BIND_IP=192.168.1.5          # comma-separated for multiple IPs
+```
+
+## Secrets management
+
+Secrets are the GitHub App credentials needed by PAC. You need four files:
+
+- `github-application-id` -- your GitHub App ID
+- `github-private-key` -- the app's private key
+- `smee` -- your smee.io or hook.pipelinesascode.com webhook URL
+- `webhook.secret` -- the shared webhook secret
+
+### Using pass
+
+Set `PAC_PASS_SECRET_FOLDER` in your config to the pass folder path:
+
+```
+github/apps/my-app
+├── github-application-id
+├── github-private-key
+├── smee
+└── webhook.secret
+```
+
+### Using plain text files
+
+Set `PAC_SECRET_FOLDER` to a directory with the same structure, files in plain text.
+
+### Second GitHub controller
+
+Set `PAC_PASS_SECOND_FOLDER` (same structure as above) and use `--github-second-ctrl` / `--second-secret=SECRET`.
+
+## PostgreSQL
+
+Customize the connection in `lib/postgresql/values.yaml`:
+
+```yaml
+global:
+  postgresql:
+    auth:
+      username: "myuser"
+      password: "mypassword"
+      database: "mydatabase"
+```
+
+Default credentials are weak and for local dev only.
+
+## Preferences
+
+Component selections are saved to `~/.config/startpaac/preferences.json` when you choose to save them. On subsequent runs, saved preferences are used automatically.
+
+```shell
+./startpaac --menu              # force the menu even with saved preferences
+./startpaac --reset-preferences # clear saved preferences
+```
+
+## Configure PAC on an existing cluster
+
+If you have PAC already installed (e.g. via the OpenShift operator):
+
+```shell
+./startpaac --configure-pac-target $KUBECONFIG $TARGET_NAMESPACE $DIRECTORY_OR_PASS_FOLDER
+```
+
+- `$KUBECONFIG` -- kubeconfig for the cluster
+- `$TARGET_NAMESPACE` -- namespace where PAC is installed (e.g. `openshift-pipelines`)
+- `$DIRECTORY_OR_PASS_FOLDER` -- secret folder (plain text dir or pass folder)
+
+## Hooks
+
+Hooks are executable scripts that run at defined points in the installation flow.
+
+### Setup
+
+Place hooks in `~/.config/startpaac/hooks/` (override with `HOOKS_DIR` env var).
+
+### Naming
+
+Files are named `pre-<component>` or `post-<component>`:
+
+```
+pre-install-tekton    -- runs before Tekton install
+post-configure-pac    -- runs after PAC configuration
+```
+
+Available hook points: `all`, `sync-kubeconfig`, `install-nginx`, `install-registry`, `install-tekton`, `install-triggers`, `install-chains`, `install-dashboard`, `install-pac`, `configure-pac`, `configure-pac-custom-certs`, `patch-pac-service-nodeport`, `install-forgejo`, `install-postgresql`, `install-custom-objects`, `install-github-second-ctrl`.
+
+### Format
+
+A hook can be a single executable file or a directory of executables (run in sorted order):
+
+```
+~/.config/startpaac/hooks/post-install-tekton           # single file
+~/.config/startpaac/hooks/post-install-tekton/01-extras  # directory of scripts
+```
+
+### Environment
+
+All existing env vars are inherited (`KUBECONFIG`, `TARGET_HOST`, `PAC_DIR`, etc.). `STARTPAC_HOOK_NAME` is exported with the current hook name.
+
+A non-zero exit from any hook aborts the run.
+
+### Example
+
+```bash
+mkdir -p ~/.config/startpaac/hooks
+cat > ~/.config/startpaac/hooks/post-install-tekton <<'EOF'
+#!/bin/bash
+echo "Tekton installed -- applying custom resources"
+kubectl apply -f ~/my-extra-resources/
+EOF
+chmod +x ~/.config/startpaac/hooks/post-install-tekton
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ Located at `~/.config/startpaac/config` (override with `STARTPAC_CONFIG_FILE` en
 
 ```bash
 # Path to your pipelines-as-code checkout (auto-detected if unset)
-PAC_DIR=~/go/src/github.com/openshift-pipelines/pipelines-as-code
+PAC_DIR=~/go/src/github.com/tektoncd/pipelines-as-code
 
 # Secrets via password-store (pass)
 # Folder structure: github-application-id, github-private-key, smee, webhook.secret

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -72,7 +72,7 @@ elif [[ -z ${PAC_DIR:-} ]]; then
 # TARGET_BIND_IP=192.168.1.5
 # TARGET_BIND_IP=192.168.1.5,10.0.0.5 # Comma-separated for multiple IPs
 # DASHBOARD=dashboard.\${DOMAIN_NAME}
-# PAC_DIR=\$GOPATH/src/github.com/openshift-pipelines/pac/main
+# PAC_DIR=\$GOPATH/src/github.com/tektoncd/pac/main
 #
 # USE_NODEPORT_WEBHOOK: Use NodePort instead of gosmee for local webhooks
 # Defaults to true when TARGET_HOST=local
@@ -82,7 +82,7 @@ elif [[ -z ${PAC_DIR:-} ]]; then
 # PAC_WEBHOOK_NODEPORT=30080
 
 # We are defaulting to a local install
-PAC_DIR=~/go/src/github.com/openshift-pipelines/pac/main
+PAC_DIR=~/go/src/github.com/tektoncd/pac/main
 PAC_SECRET_FOLDER=~/.local/share/startpaac/secrets
 TARGET_HOST=local
 EOF

--- a/misc/forgejo-mng/README.md
+++ b/misc/forgejo-mng/README.md
@@ -2,7 +2,7 @@
 
 A lightweight tool for quickly setting up Forgejo repositories and Pipelines-as-Code integration for testing and development. Automates repository creation, webhook configuration, and Kubernetes resources needed for PAC.
 
-Originally designed as part of the [startpaac](https://github.com/openshift-pipelines/pipelines-as-code) project but can be used independently.
+Originally designed as part of the [startpaac](https://github.com/tektoncd/pipelines-as-code) project but can be used independently.
 
 **Use this for:**
 

--- a/startpaac
+++ b/startpaac
@@ -21,7 +21,7 @@ else
   }
 
   cd "${PAC_DIR:-}" || {
-    echo "cannot find the pipelines-as-code directory, set the PAC_DIR variable to where you have checked out the github.com/openshift-pipelines/pipelines-as-code repository in your ${HOME}/.config/startpaac/config"
+    echo "cannot find the pipelines-as-code directory, set the PAC_DIR variable to where you have checked out the github.com/tektoncd/pipelines-as-code repository in your ${HOME}/.config/startpaac/config"
     exit 1
   }
 fi


### PR DESCRIPTION
Moved detailed technical configuration and reference material from the main README to a dedicated configuration documentation file. Updated the README to focus on quick start and usage, and updated the architecture documentation to link to the new configuration guide. split documentation and less slop