### PR TITLE
chore: make gum and ko optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,13 @@ See [docs/configuration.md](docs/configuration.md) for the full reference (remot
 
 ## Prerequisites
 
-docker, kind, helm, kubectl, ko, gum, jq, minica
+docker, kind, helm, kubectl, jq, minica
 
-Optional: [pass](https://www.passwordstore.org/) for secrets management
+Optional:
+
+- [ko](https://ko.build/) - only needed when deploying PAC from source (`-p`, `-a`, `-c` flags)
+- [gum](https://github.com/charmbracelet/gum) - enhances interactive menus (falls back to plain bash prompts)
+- [pass](https://www.passwordstore.org/) - for secrets management
 
 macOS users: install [coreutils](https://formulae.brew.sh/formula/coreutils) and [gnu-sed](https://formulae.brew.sh/formula/gnu-sed) from Homebrew.
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -199,18 +199,12 @@ check_tools() {
     "curl"
     "docker"
     "kind"
-    "ko"
     "base64"
     "sed"
     "mktemp"
     "readlink"
     "jq"
   )
-
-  # Only require gum in interactive mode
-  if [[ ${CI_MODE:-false} != "true" ]]; then
-    tools+=("gum")
-  fi
 
   # minica is required for TLS certificate generation
   tools+=("minica")
@@ -234,6 +228,92 @@ check_tools() {
     fi
   fi
   return 0
+}
+
+# Check for a tool at point-of-use and exit with a clear error if missing
+require_tool() {
+  local tool=$1
+  if ! command -v "${tool}" &>/dev/null; then
+    echo "Error: ${tool} is required for this operation but is not installed or not in PATH."
+    exit 1
+  fi
+}
+
+# Wrapper around gum confirm with bash fallback
+_confirm() {
+  local prompt="${1:-Confirm?}"
+  if command -v gum &>/dev/null; then
+    gum confirm "${prompt}"
+  else
+    local answer
+    read -r -p "${prompt} [y/N] " answer </dev/tty
+    [[ ${answer} =~ ^[Yy]$ ]]
+  fi
+}
+
+# Wrapper around gum choose --no-limit with bash fallback
+# Usage: echo "items" | _choose_multi [--selected="item1,item2"]
+_choose_multi() {
+  local preselected=""
+  for arg in "$@"; do
+    case "${arg}" in
+    --selected=*) preselected="${arg#--selected=}" ;;
+    esac
+  done
+
+  if command -v gum &>/dev/null; then
+    if [[ -n ${preselected} ]]; then
+      gum choose --no-limit --selected="${preselected}"
+    else
+      gum choose --no-limit
+    fi
+    return
+  fi
+
+  # Bash fallback: numbered toggle menu
+  local -a items=()
+  local -a selected=()
+  while IFS= read -r line; do
+    [[ -z ${line} ]] && continue
+    items+=("${line}")
+    if [[ ",${preselected}," == *",${line},"* ]]; then
+      selected+=(1)
+    else
+      selected+=(0)
+    fi
+  done
+
+  local count=${#items[@]}
+  [[ ${count} -eq 0 ]] && return
+
+  while true; do
+    echo "" >&2
+    for i in $(seq 0 $((count - 1))); do
+      local marker="[ ]"
+      [[ ${selected[$i]} -eq 1 ]] && marker="[x]"
+      printf "  %d) %s %s\n" "$((i + 1))" "${marker}" "${items[$i]}" >&2
+    done
+    echo "" >&2
+    local input
+    read -r -p "Toggle a number, or press Enter when done: " input </dev/tty
+    if [[ -z ${input} || ${input} == "d" ]]; then
+      break
+    fi
+    if [[ ${input} =~ ^[0-9]+$ ]] && ((input >= 1 && input <= count)); then
+      local idx=$((input - 1))
+      if [[ ${selected[idx]} -eq 0 ]]; then
+        selected[idx]=1
+      else
+        selected[idx]=0
+      fi
+    else
+      echo "Invalid input, enter a number between 1 and ${count}" >&2
+    fi
+  done
+
+  for i in $(seq 0 $((count - 1))); do
+    [[ ${selected[$i]} -eq 1 ]] && echo "${items[$i]}"
+  done
 }
 
 makeGosmee() {

--- a/startpaac
+++ b/startpaac
@@ -313,6 +313,8 @@ install_pac() {
   extras=()
   [[ -e "${PAC_DIR}/pkg/test/nonoai/deployment.yaml" ]] && extras+=(-f "${PAC_DIR}/pkg/test/nonoai/deployment.yaml")
 
+  require_tool ko
+
   # Verify registry is accessible before ko resolve
   echo "Verifying registry ${REGISTRY} is accessible..."
   local reg_ok=false
@@ -613,6 +615,8 @@ function install_github_second_ctrl() {
     pac_controller_smee_url=$(cat ${PAC_SECOND_SECRET_FOLDER}/smee)
   fi
 
+  require_tool ko
+
   type -p uv >/dev/null 2>&1 || {
     echo "Installing uv tool to generate second controller yaml"
     curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -864,9 +868,9 @@ show_component_menu() {
   preselected=$(get_preselected_items | paste -sd, -)
 
   if [[ -n ${preselected} ]]; then
-    selected_items=$(echo "${menu_items}" | gum choose --no-limit --selected="${preselected}")
+    selected_items=$(echo "${menu_items}" | _choose_multi --selected="${preselected}")
   else
-    selected_items=$(echo "${menu_items}" | gum choose --no-limit)
+    selected_items=$(echo "${menu_items}" | _choose_multi)
   fi
 
   parse_menu_selections "${selected_items}"
@@ -875,7 +879,7 @@ show_component_menu() {
 # Ask user if they want to save preferences
 prompt_save_preferences() {
   echo ""
-  if gum confirm "Save these preferences for next time?"; then
+  if _confirm "Save these preferences for next time?"; then
     save_preferences
     echo_color brightgreen "Preferences saved to ${PREFERENCES_FILE}"
   fi
@@ -1182,7 +1186,7 @@ function parse_args() {
   show_selected_components
 
   # Final confirmation
-  if ! gum confirm "Proceed with installation?"; then
+  if ! _confirm "Proceed with installation?"; then
     echo "Installation cancelled."
     exit 1
   fi


### PR DESCRIPTION
## Summary
- **gum**: Add bash fallback helpers (`_confirm`, `_choose_multi`) so interactive mode works without gum installed. When gum is available it's still used; otherwise falls back to plain `read` prompts and a numbered toggle menu.
- **ko**: Remove from startup tool check; add `require_tool ko` at point-of-use in `install_pac()` and `install_github_second_ctrl()` since it's only needed when building PAC from source.
- Update README to list gum and ko as optional prerequisites.

## Test plan
- [ ] `./startpaac --help` works without gum or ko installed
- [ ] `./startpaac --menu` without gum shows bash numbered menu fallback
- [ ] `./startpaac --menu` with gum uses gum as before
- [ ] `./startpaac --ci` works unchanged
- [ ] shellcheck passes on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)