### PR TITLE
fix: wait for webhook pod readiness before patching Tekton config

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -160,6 +160,13 @@ wait_for_resource() {
         ep=$(kubectl get ep -n "${namespace}" "${name}" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)
         [[ -n ${ep} ]] && is_ready=1
         ;;
+      pod)
+        kubectl wait --for=condition=Ready pods \
+          -l "${name}" \
+          -n "${namespace}" \
+          --timeout=0s \
+          &>/dev/null && is_ready=1
+        ;;
       deployment|deploy)
         local desired ready
         desired=$(kubectl get deployment -n "${namespace}" "${name}" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")

--- a/startpaac
+++ b/startpaac
@@ -246,7 +246,21 @@ install_tekton() {
   release_yaml=$(cache_yaml_file tekton https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml)
   kubectl apply --filename "${release_yaml}" >/dev/null
   wait_for_resource endpoint tekton-pipelines tekton-pipelines-webhook
-  kubectl patch configmap -n tekton-pipelines --type merge -p '{"data":{"enable-step-actions": "true"}}' feature-flags
+  wait_for_resource pod tekton-pipelines app=tekton-pipelines-webhook
+
+  local patch='{"data":{"enable-step-actions": "true"}}'
+  local max_attempts=5
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if kubectl patch configmap -n tekton-pipelines --type merge -p "${patch}" feature-flags 2>/dev/null; then
+      break
+    fi
+    if [[ ${attempt} -eq ${max_attempts} ]]; then
+      echo_color brightred "Failed to patch feature-flags after ${max_attempts} attempts"
+      return 1
+    fi
+    echo_color brightwhite "Webhook not ready yet, retrying in 5s (${attempt}/${max_attempts})..."
+    sleep 5
+  done
 }
 
 install_triggers() {


### PR DESCRIPTION
## Summary

- Adds a `pod` case to `wait_for_resource()` in `lib/common.sh` that uses `kubectl wait --for=condition=Ready`, which respects the pod readiness probe — a much stronger signal than endpoint IP presence
- In `install_tekton()`, adds a pod readiness check after the endpoint check and wraps `kubectl patch` in a 5-attempt retry loop (5s backoff) to handle the race condition where the TLS webhook listener isn't yet accepting connections

## Problem

After `wait_for_resource endpoint` passes (endpoint has an IP), the next command `kubectl patch configmap` triggers the Tekton admission webhook, which fails with:

```
Error from server (InternalError): failed calling webhook "config.webhook.pipeline.tekton.dev": 
Post "https://tekton-pipelines-webhook...svc:443/...": dial tcp ...: connect: connection refused
```

Endpoint IP ≠ webhook TLS listener ready.

## Test plan

- [ ] Run `startpaac` against a fresh kind/k3s cluster and confirm "Deploying Tekton" completes without the webhook InternalError
- [ ] Confirm `kubectl get cm feature-flags -n tekton-pipelines -o jsonpath='{.data.enable-step-actions}'` returns `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)