### PR TITLE
refactor: Wrap direct component commands with hook support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,9 @@ pre-install-tekton    -- runs before Tekton install
 post-configure-pac    -- runs after PAC configuration
 ```
 
-Available hook points: `all`, `sync-kubeconfig`, `install-nginx`, `install-registry`, `install-tekton`, `install-triggers`, `install-chains`, `install-dashboard`, `install-pac`, `configure-pac`, `configure-pac-custom-certs`, `patch-pac-service-nodeport`, `install-forgejo`, `install-postgresql`, `install-custom-objects`, `install-github-second-ctrl`.
+Available hook points: `all`, `sync-kubeconfig`, `install-nginx`, `install-registry`, `install-tekton`, `install-triggers`, `install-chains`, `install-dashboard`, `install-pac`, `configure-pac`, `configure-pac-custom-certs`, `patch-pac-service-nodeport`, `install-forgejo`, `setup-forgejo-sample`, `install-postgresql`, `install-custom-objects`, `install-github-second-ctrl`.
+
+Hooks run in the full install flows and in matching direct component commands such as `--install-tekton`, `--install-paac`, `--install-forgejo`, and `--configure-pac`.
 
 ### Format
 
@@ -127,7 +129,7 @@ A hook can be a single executable file or a directory of executables (run in sor
 
 ### Environment
 
-All existing env vars are inherited (`KUBECONFIG`, `TARGET_HOST`, `PAC_DIR`, etc.). `STARTPAC_HOOK_NAME` is exported with the current hook name.
+Hooks inherit the current environment. startpaac also exports its scalar runtime/config values for hooks (`KUBECONFIG`, `TARGET_HOST`, `PAC_DIR`, etc.). `STARTPAC_HOOK_NAME` is exported with the current hook name; `STARTPAAC_HOOK_NAME` is also available as an alias.
 
 A non-zero exit from any hook aborts the run.
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -370,6 +370,58 @@ EOF
 
 HOOKS_DIR="${HOOKS_DIR:-${HOME}/.config/startpaac/hooks}"
 
+export_hook_environment() {
+    local -a hook_env_vars=(
+        CERT_DIR
+        CI_MODE
+        CONFIG_FILE
+        DASHBOARD
+        DOMAIN_NAME
+        FORCE_INTERACTIVE
+        FORGE_HOST
+        HOOKS_DIR
+        INSTALL_CUSTOM_OBJECT
+        INSTALL_CUSTOM_OBJECT_ENABLED
+        INSTALL_FORGE
+        INSTALL_GITHUB_SECOND_CTRL
+        INSTALL_PAC
+        INSTALL_POSTGRESQL
+        INSTALL_TEKTON_CHAINS
+        INSTALL_TEKTON_DASHBOARD
+        INSTALL_TEKTON_TRIGGERS
+        KO_DEFAULTBASEIMAGE
+        KUBECONFIG
+        PAC
+        PAC_CONTROLLER_TARGET_NS
+        PAC_DEBUG_IMAGE
+        PAC_DIR
+        PAC_DOMAIN
+        PAC_IMAGE_NONROOT
+        PAC_PASS_SECOND_FOLDER
+        PAC_PASS_SECRET_FOLDER
+        PAC_SECOND_SECRET_FOLDER
+        PAC_SECRET_FOLDER
+        PAC_WEBHOOK_NODEPORT
+        PAC_WEBHOOK_SECRET
+        PAC_WEB_URL
+        PREFERENCES_FILE
+        REGISTRY
+        SP
+        TARGET_BIND_IP
+        TARGET_HOST
+        TMPFILE
+        USE_NODEPORT_WEBHOOK
+    )
+    local var declaration
+
+    for var in "${hook_env_vars[@]}"; do
+        [[ -v ${var} ]] || continue
+        declaration=$(declare -p "${var}" 2>/dev/null || true)
+        [[ ${declaration} == declare\ -a* || ${declaration} == declare\ -A* ]] && continue
+        export "${var?}"
+    done
+}
+
 run_hook() {
     local hook_name="$1"
     local hook_path="${HOOKS_DIR}/${hook_name}"
@@ -387,7 +439,9 @@ run_hook() {
 
     [[ ${#hook_files[@]} -eq 0 ]] && return 0
 
+    export_hook_environment
     export STARTPAC_HOOK_NAME="${hook_name}"
+    export STARTPAAC_HOOK_NAME="${hook_name}"
     for hook_file in "${hook_files[@]}"; do
         local display_name="${hook_name}"
         [[ ${#hook_files[@]} -gt 1 ]] && display_name="${hook_name}/$(basename "${hook_file}")"

--- a/startpaac
+++ b/startpaac
@@ -987,23 +987,23 @@ function parse_args() {
       shift
       ;;
     -g | --install-forgejo) # Install Forgejo
-      install_forgejo ${FORGE_HOST}
-      setup_forgejo_sample
+      run_with_hooks install-forgejo install_forgejo ${FORGE_HOST}
+      run_with_hooks setup-forgejo-sample setup_forgejo_sample
       exit
       ;;
     -s | --sync-kubeconfig) # Sync kubeconfig
-      sync_kubeconfig
+      run_with_hooks sync-kubeconfig sync_kubeconfig
       exit
       ;;
     -S | --github-second-ctrl) # Deploy second controller for github
-      install_github_second_ctrl
+      run_with_hooks install-github-second-ctrl install_github_second_ctrl
       exit
       ;;
     -H | --all-github-second-no-forgejo) # Install everything but forgejo
       INSTALL_FORGE=false
       install_kind
       all
-      install_github_second_ctrl
+      run_with_hooks install-github-second-ctrl install_github_second_ctrl
       show_config
       exit
       ;;
@@ -1017,7 +1017,7 @@ function parse_args() {
       exit
       ;;
     -t | --install-tekton) # Install Tekton
-      install_tekton
+      run_with_hooks install-tekton install_tekton
       exit
       ;;
     -a | --all) # Install everything
@@ -1031,20 +1031,20 @@ function parse_args() {
       exit
       ;;
     -c | --deploy-component) # Install a specific component
-      install_pac "$2"
+      run_with_hooks install-pac install_pac "$2"
       shift
       exit
       ;;
     -p | --install-paac) # Deploy and configure PAC
-      install_pac
-      configure_pac
-      configure_pac_custom_certs
-      patch_pac_service_nodeport
+      run_with_hooks install-pac install_pac
+      run_with_hooks configure-pac configure_pac
+      run_with_hooks configure-pac-custom-certs configure_pac_custom_certs
+      run_with_hooks patch-pac-service-nodeport patch_pac_service_nodeport
       exit
       ;;
     -k | --kind) # Install Kind
       install_kind
-      sync_kubeconfig
+      run_with_hooks sync-kubeconfig sync_kubeconfig
       exit
       ;;
     -i | --menu | --interactive) # Force interactive component selection menu
@@ -1059,14 +1059,14 @@ function parse_args() {
       exit 0
       ;;
     --setup-forgejo-sample) # Setup sample Forgejo user and repo
-      setup_forgejo_sample
+      run_with_hooks setup-forgejo-sample setup_forgejo_sample
       exit
       ;;
     --debug-image) # use a debug image to apply KO images
       show_step "Using debug image:  ${PAC_DEBUG_IMAGE}"
       export KO_DEFAULTBASEIMAGE=${PAC_DEBUG_IMAGE}
       PAC_IMAGE_NONROOT=false
-      install_pac
+      run_with_hooks install-pac install_pac
       echo
       echo "You can oc rsh to controller (or watcher, webhook) with:"
       echo "kubectl exec -it deployment/pipelines-as-code-controller -- bash"
@@ -1075,7 +1075,7 @@ function parse_args() {
     --second-secret) # Set the secret for the second controller
       PAC_PASS_SECOND_FOLDER=$2
       shift
-      install_github_second_ctrl
+      run_with_hooks install-github-second-ctrl install_github_second_ctrl
       exit
       ;;
     --show-config) # Show configuration
@@ -1083,40 +1083,40 @@ function parse_args() {
       exit
       ;;
     --install-registry) # Install docker registry
-      install_registry
+      run_with_hooks install-registry install_registry
       exit
       ;;
     --install-postgresql) # Install PostgreSQL
-      install_postgresql
+      run_with_hooks install-postgresql install_postgresql
       exit
       ;;
     --install-dashboard) # Install Tekton dashboard
-      install_dashboard
+      run_with_hooks install-dashboard install_dashboard
       exit
       ;;
     --install-triggers) # Install Tekton triggers
-      install_triggers
+      run_with_hooks install-triggers install_triggers
       exit
       ;;
     --install-chains) # Install Tekton chains
-      install_chains
+      run_with_hooks install-chains install_chains
       exit
       ;;
     --install-nginx) # Install Nginx
-      install_nginx
+      run_with_hooks install-nginx install_nginx
       exit
       ;;
     --all-to-tekton) # Install everything up to Tekton
       install_kind
-      sync_kubeconfig
-      install_nginx
-      install_registry
-      install_tekton
+      run_with_hooks sync-kubeconfig sync_kubeconfig
+      run_with_hooks install-nginx install_nginx
+      run_with_hooks install-registry install_registry
+      run_with_hooks install-tekton install_tekton
       show_config
       exit
       ;;
     --configure-pac) # Configure PAC
-      configure_pac
+      run_with_hooks configure-pac configure_pac
       exit
       ;;
     --configure-pac-target) # Configure PAC to a target, this won't configure a ingress
@@ -1133,12 +1133,12 @@ function parse_args() {
         echo "Cannot find $5 folder or ~/.password-store/$5 folder"
         exit 1
       fi
-      configure_pac --no-ingress
+      run_with_hooks configure-pac configure_pac --no-ingress
       if [[ "${USE_NODEPORT_WEBHOOK}" != "true" ]]; then
         show_step "Creating gosmee service in namespace gosmee"
         makeGosmee gosmee ${smee_url} http://pipelines-as-code-controller.$PAC_CONTROLLER_TARGET_NS.svc.cluster.local:8080 gosmee
       else
-        patch_pac_service_nodeport
+        run_with_hooks patch-pac-service-nodeport patch_pac_service_nodeport
         echo "NodePort webhook enabled, skipping gosmee deployment"
       fi
       exit
@@ -1150,7 +1150,7 @@ function parse_args() {
     --redeploy-kind) # Redeploy Kind
       stop_kind
       install_kind
-      sync_kubeconfig
+      run_with_hooks sync-kubeconfig sync_kubeconfig
       exit
       ;;
     --ci) # Non-interactive CI mode (skips gum, uses TLS with minica)


### PR DESCRIPTION
All direct CLI flags (e.g. `--install-tekton`, `--install-forgejo`,
`--configure-pac`) were calling component functions directly, bypassing
the hook system entirely. They were updated to go through
`run_with_hooks` so pre/post hooks fire consistently whether a
component is invoked standalone or as part of a full install.

A new `export_hook_environment` function was added to explicitly export
all scalar runtime and config variables to hook scripts, replacing the
implicit inheritance that previously only exposed whatever happened to
be in the environment. The `STARTPAAC_HOOK_NAME` alias was also
introduced alongside `STARTPAC_HOOK_NAME` for naming consistency.
The `setup-forgejo-sample` hook point was added to the available list.

Documentation was updated to reflect the new hook point, the expanded
variable export behaviour, and the fact that hooks now fire in direct
component commands as well as full install flows.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
